### PR TITLE
Fix failing doc-test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 //! ```rust
 //! # use sepax2d::prelude::*;
 //!
-//! let triangle = Polygon::from_vertices((0.0, vec![(0.0, 0.0), (1.0, 1.0), (-1.0, 1.0)]));
+//! let triangle = Polygon::from_vertices((0.0, 0.0), vec![(0.0, 0.0), (1.0, 1.0), (-1.0, 1.0)]);
 //!
 //! assert!(intersects_segment(&triangle, (2.0, 0.5), (-2.0, 0.5)));
 //! ```


### PR DESCRIPTION
Self-explanatory. The doc-test fails to compile because arguments passed do not match the method's signature.